### PR TITLE
feat: add `json::primitive!` macro and deprecate `json::value!`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,7 +55,7 @@ body:
                 data,
                 json::matches_pattern!({
                     "user": json::matches_pattern!({
-                        "name": json::value!(eq("Alice")),
+                        "name": json::primitive!(eq("Alice")),
                         "settings": json::is_null(),
                     })
                 })

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -38,8 +38,8 @@ body:
         assert_that!(
             j!(["item1", "item2", "target", "other", "another_target", "item3"]),
             json::contains_sequence![
-                json::value!(eq("target")),
-                json::value!(eq("another_target"))
+                json::primitive!(eq("target")),
+                json::primitive!(eq("another_target"))
             ]
         );
         ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ version = "0.1.0"
 dependencies = [
  "googletest",
  "indoc",
+ "serde",
  "serde_json",
 ]
 
@@ -137,27 +138,27 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 googletest = "0.14.2"
+serde = "1.0.228"
 serde_json = "1.0.145"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These tiny, focused matchers make it effortless to assert on `serde_json::Value`
 
 ## Features
 
-- **Value**: Match JSON primitive values (`string`, `number` (i64/f64), `bool`) using the `json::value!` macro, and
+- **Value**: Match JSON primitive values (`string`, `number` (i64/f64), `bool`) using the `json::primitive!` macro, and
   match `null` values with `json::is_null()`.
 - **Object**: Pattern-match JSON objects by fields using the `json::matches_pattern!{...}` macro; supports both *
   *strict** mode (
@@ -63,7 +63,7 @@ use serde_json::json as j;
 ```
 
 > The crate re-exports a `json` namespace with everything you need:
-> - `json::value!(...)` – match a value inside a JSON `Value`
+> - `json::primitive!(...)` – match a value inside a JSON `Value`
 > - `json::matches_pattern!` – explicitly match JSON objects by fields (with `json::pat!` as an alias)
 > - `json::elements_are![...]` – match arrays element-by-element (ordered)
 > - `json::unordered_elements_are![...]` – match arrays element-by-element (unordered)
@@ -81,10 +81,10 @@ use serde_json::json as j;
 # use serde_json::json as j;
 
 fn values() {
-    assert_that!(j!(42),        json::value!(gt(40i64)));
-    assert_that!(j!(3.14),      json::value!(near(3.1f64, 0.1f64)));
-    assert_that!(j!("hello"),   json::value!(starts_with("he")));
-    assert_that!(j!(true),      json::value!(is_true()));
+    assert_that!(j!(42),        json::primitive!(gt(40i64)));
+    assert_that!(j!(3.14),      json::primitive!(near(3.1f64, 0.1f64)));
+    assert_that!(j!("hello"),   json::primitive!(starts_with("he")));
+    assert_that!(j!(true),      json::primitive!(is_true()));
     assert_that!(j!(null),     json::is_null());
 }
 ```
@@ -265,8 +265,8 @@ fn combined_match() {
             payload: json::matches_pattern!({
                 "user": json::matches_pattern!({
                     // Value matchers
-                    "id": json::value!(gt(100i64)),
-                    "name": json::value!(starts_with("Ali")),
+                    "id": json::primitive!(gt(100i64)),
+                    "name": json::primitive!(starts_with("Ali")),
                     
                     // Ordered array matching
                     "roles": json::elements_are![eq("admin"), eq("user"), eq("tester")],
@@ -276,8 +276,8 @@ fn combined_match() {
                     
                     // Nested object with null value
                     "settings": json::matches_pattern!({
-                        "theme": json::value!(eq("dark")),
-                        "notifications": json::value!(is_true()),
+                        "theme": json::primitive!(eq("dark")),
+                        "notifications": json::primitive!(is_true()),
                         "beta_features": json::is_null(),
                     }),
                     
@@ -288,7 +288,7 @@ fn combined_match() {
                     
                     // Non-strict object matching (allows extra fields)
                     "metadata": json::matches_pattern!({
-                        "created": json::value!(starts_with("2021")),
+                        "created": json::primitive!(starts_with("2021")),
                         ..
                     }),
                     

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -5,11 +5,12 @@ mod value_matcher;
 
 pub use value_matcher::is_null;
 
+#[allow(deprecated)]
 #[doc(inline)]
 pub use crate::{
     __json_contains_each as contains_each, __json_elements_are as elements_are,
     __json_is_contained_in as is_contained_in, __json_matches_pattern as pat,
-    __json_matches_pattern as matches_pattern,
+    __json_matches_pattern as matches_pattern, __json_primitive as primitive,
     __json_unordered_elements_are as unordered_elements_are, __json_value as value,
 };
 

--- a/src/matchers/matches_pattern_matcher.rs
+++ b/src/matchers/matches_pattern_matcher.rs
@@ -17,7 +17,7 @@
 ///     value,
 ///     json::pat!({
 ///         "name": eq("Alice"),
-///         "age": json::value!(ge(18i64)),
+///         "age": json::primitive!(ge(18i64)),
 ///         .. // allows additional fields
 ///     })
 /// );
@@ -49,7 +49,7 @@
 ///
 /// - Matchers like `eq(...)` can be used directly.
 /// - For non-`Value` matchers (e.g., `starts_with`, `contains_substring`), wrap them in
-///   `json::value!(...)`.
+///   `json::primitive!(...)`.
 ///
 /// # Alias
 ///

--- a/src/matchers/value_matcher.rs
+++ b/src/matchers/value_matcher.rs
@@ -20,9 +20,38 @@
 /// verify_that!(data["active"], json::value!(eq(true)));
 /// verify_that!(data["count"], json::value!(ge(0)));
 /// ```
+#[deprecated(since = "0.2.0", note = "please use `json::primitive!` instead")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __json_value {
+    ($matcher:expr) => {
+        $crate::__json_primitive!($matcher)
+    };
+}
+
+/// Matches a JSON value (string, number, or boolean) against the given matcher.
+///
+/// This macro enables matching specific primitive values inside a JSON structure
+/// by delegating to a matcher for the corresponding Rust type. It supports:
+/// - `String` values (e.g. `json::primitive!(eq("hello"))`)
+/// - `Number` values as `i64` or `f64` (e.g. `json::primitive!(ge(0))`)
+/// - `Boolean` values (e.g. `json::primitive!(eq(true))`)
+///
+/// Fails if the value is not of the expected JSON type.
+///
+/// # Example
+/// ```
+/// # use googletest::prelude::*;
+/// # use googletest_json_serde::json;
+/// # use serde_json::json as j;
+/// let data = j!({"active": true, "count": 3});
+///
+/// verify_that!(data["active"], json::primitive!(eq(true)));
+/// verify_that!(data["count"], json::primitive!(ge(0)));
+/// ```
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __json_primitive {
     ($matcher:expr) => {
         $crate::matchers::__internal_unstable_do_not_depend_on_these::JsonValueMatcher::new(
             $matcher,

--- a/tests/is_contained_in_test.rs
+++ b/tests/is_contained_in_test.rs
@@ -82,7 +82,7 @@ fn is_contained_in_explains_missing_elements_in_mismatch() -> Result<()> {
 
 #[test]
 fn is_contained_in_explains_mismatch_due_to_no_graph_matching_found() -> Result<()> {
-    let matcher = json::is_contained_in![json::value!(ge(1_i64)), json::value!(ge(3_i64))];
+    let matcher = json::is_contained_in![json::primitive!(ge(1_i64)), json::primitive!(ge(3_i64))];
     verify_that!(
         matcher.explain_match(&j!([1, 2])),
         displays_as(eq(indoc!(

--- a/tests/value_test.rs
+++ b/tests/value_test.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 #[test]
 fn i64_wrong_type() -> Result<()> {
     let val = json!(true);
-    let result = verify_that!(val, json::value!(gt(10)));
+    let result = verify_that!(val, json::primitive!(gt(10)));
     verify_that!(
         result,
         err(displays_as(starts_with(indoc!(
@@ -21,7 +21,7 @@ fn i64_wrong_type() -> Result<()> {
 #[test]
 fn f64_wrong_type() -> Result<()> {
     let val = json!("wat");
-    let result = verify_that!(val, json::value!(gt(1.0)));
+    let result = verify_that!(val, json::primitive!(gt(1.0)));
     verify_that!(
         result,
         err(displays_as(starts_with(indoc!(
@@ -36,7 +36,7 @@ fn f64_wrong_type() -> Result<()> {
 #[test]
 fn bool_wrong_type() -> Result<()> {
     let val = json!(123);
-    let result = verify_that!(val, json::value!(is_true()));
+    let result = verify_that!(val, json::primitive!(is_true()));
     verify_that!(
         result,
         err(displays_as(starts_with(indoc!(
@@ -51,26 +51,26 @@ fn bool_wrong_type() -> Result<()> {
 #[test]
 fn f64_nan_not_match() -> Result<()> {
     let val = json!(f64::NAN);
-    verify_that!(val, not(json::value!(eq(5.0))))
+    verify_that!(val, not(json::primitive!(eq(5.0))))
 }
 
 #[test]
 fn string_type() -> Result<()> {
     let val = json!("hello");
-    verify_that!(val, json::value!(eq("hello")))
+    verify_that!(val, json::primitive!(eq("hello")))
 }
 #[test]
 fn i64_type() -> Result<()> {
     let val = json!(99i64);
-    verify_that!(val, json::value!(eq(99i64)))
+    verify_that!(val, json::primitive!(eq(99i64)))
 }
 #[test]
 fn f64_type() -> Result<()> {
     let val = json!(99.3f64);
-    verify_that!(val, json::value!(eq(99.3f64)))
+    verify_that!(val, json::primitive!(eq(99.3f64)))
 }
 #[test]
 fn bool_type() -> Result<()> {
     let val = json!(false);
-    verify_that!(val, json::value!(is_false()))
+    verify_that!(val, json::primitive!(is_false()))
 }


### PR DESCRIPTION
Introduces a new json::primitive! macro focused on matching JSON primitive types (string, number, boolean), keeping semantics aligned with the JSON RFC.

json::value! is marked deprecated for now because it semantically implies support for all JSON types, but there isn’t yet a clean, practical way to support arrays or objects in a type-safe and ergonomic manner.

The deprecation is soft — if a future design allows safely extending json::value! to all JSON types without ambiguity, it may be reinstated. For now, json::primitive! ensures clarity of intent and aligns better with other json::* matchers.