### PR TITLE
test: add nested and edge case coverage for JSON matchers

### DIFF
--- a/tests/contains_each_test.rs
+++ b/tests/contains_each_test.rs
@@ -132,3 +132,51 @@ fn contains_each_wrong_type_failure_message() -> Result<()> {
         err(displays_as(contains_substring("which is not a JSON array")))
     )
 }
+
+#[test]
+fn contains_each_nested_full_match() -> Result<()> {
+    verify_that!(
+        j!([["x", "y"], ["a", "b"]]),
+        json::contains_each![
+            json::contains_each![eq("x"), eq("y")],
+            json::contains_each![eq("a"), eq("b")]
+        ]
+    )
+}
+#[test]
+fn contains_each_nested_partial_match() -> Result<()> {
+    verify_that!(
+        j!([["x", "y"], ["a", "b"]]),
+        json::contains_each![json::contains_each![eq("x")], json::contains_each![eq("a")]]
+    )
+}
+
+#[test]
+fn contains_each_partial_nested_mismatch() -> Result<()> {
+    verify_that!(
+        j!([["x", "y"], ["a", "b"]]),
+        not(json::contains_each![
+            json::contains_each![eq("x"), eq("z")],
+            json::contains_each![eq("a"), eq("b")]
+        ])
+    )
+}
+
+#[test]
+fn contains_each_nested_wrong_type() -> Result<()> {
+    verify_that!(
+        j!([{"x": 1}, ["a", "b"]]),
+        not(json::contains_each![
+            json::contains_each![eq("x")],
+            json::contains_each![eq("a"), eq("b")]
+        ])
+    )
+}
+
+#[test]
+fn contains_each_empty_input_nested_matchers() -> Result<()> {
+    verify_that!(
+        j!([]),
+        not(json::contains_each![json::contains_each![eq("a")]])
+    )
+}

--- a/tests/is_contained_in_test.rs
+++ b/tests/is_contained_in_test.rs
@@ -93,3 +93,46 @@ fn is_contained_in_explains_mismatch_due_to_no_graph_matching_found() -> Result<
               Expected element `is greater than or equal to 3` at index 1 did not match any remaining actual element."))
     ))
 }
+
+#[test]
+fn is_contained_in_matches_nested_arrays() -> Result<()> {
+    let data = j!([[1, 2], [3, 4]]);
+    verify_that!(
+        data,
+        json::is_contained_in![
+            json::is_contained_in![eq(1), eq(2)],
+            json::is_contained_in![eq(3), eq(4)]
+        ]
+    )
+}
+
+#[test]
+fn is_contained_in_handles_mixed_types() -> Result<()> {
+    let data = j!([1, "a", true]);
+    verify_that!(
+        data,
+        json::is_contained_in![eq(1), eq("a"), eq(true), eq(false)]
+    )
+}
+
+#[test]
+fn is_contained_in_with_duplicates_should_fail() -> Result<()> {
+    verify_that!(j!([1, 1, 2]), not(json::is_contained_in![eq(1), eq(2)]))
+}
+
+#[test]
+fn is_contained_in_with_empty_expected_should_fail() -> Result<()> {
+    verify_that!(j!([1, 2, 3]), not(json::is_contained_in![]))
+}
+
+#[test]
+fn is_contained_in_explains_nested_mismatch() -> Result<()> {
+    let matcher = json::is_contained_in![
+        json::is_contained_in![eq(1), eq(999)],
+        json::is_contained_in![eq(3), eq(4)]
+    ];
+    verify_that!(
+        matcher.explain_match(&j!([[1, 2], [3, 4]])),
+        displays_as(contains_substring("element #0"))
+    )
+}

--- a/tests/unordered_elements_test.rs
+++ b/tests/unordered_elements_test.rs
@@ -92,7 +92,34 @@ fn unordered_elements_are_unmatchable_actual_description_mismatch() -> Result<()
         displays_as(eq("whose element #1 does not match any expected elements"))
     )
 }
+#[test]
+fn unordered_elements_are_matches_when_expected_duplicates_are_fully_matched() -> Result<()> {
+    let value = json!(["a", "b"]);
+    verify_that!(
+        value,
+        json::unordered_elements_are![eq("a"), eq("a"), eq("b")]
+    )
+}
+#[test]
+fn unordered_elements_are_fails_with_extra_actual_elements() -> Result<()> {
+    let value = json!(["a", "b", "c", "d"]);
+    verify_that!(
+        value,
+        not(json::unordered_elements_are![eq("a"), eq("b"), eq("c")])
+    )
+}
 
+#[test]
+fn unordered_elements_are_matches_nested_unordered_arrays() -> Result<()> {
+    let value = json!([["x", "y"], ["z"]]);
+    verify_that!(
+        value,
+        json::unordered_elements_are![
+            json::unordered_elements_are![eq("z")],
+            json::unordered_elements_are![eq("y"), eq("x")]
+        ]
+    )
+}
 #[test]
 fn unordered_elements_are_fails_and_includes_full_message() -> Result<()> {
     let result = verify_that!(


### PR DESCRIPTION
Added deep nested tests for `contains_each`, `is_contained_in`, and `unordered_elements_are`