### PR TITLE
ci: add manual release workflows using Release-plz for PR preparation and crate publishing  

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,44 @@
+name: Create or Update Release PR
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  release-pr:
+    name: Create or Update Release Preparation PR
+    runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'chege' }}
+    permissions:
+      contents: read
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    environment: 'release'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+      # Generating a GitHub token, so that PRs and tags created by
+      # the release-plz-action can trigger actions workflows.
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+      - name: Run `release-plz release-pr`
+        uses: release-plz/action@acb9246af4d59a270d1d4058a8b9af8c3f3a2559 # v0.5.117
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Publish Crate and Create GitHub Release
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  release:
+    name: Tag, Publish Crate, and Create GitHub Release
+    runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'chege' }}
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # Required for trusted publishing
+    steps:
+      - &checkout
+        name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - &setup-rust
+        name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+      # Generating a GitHub token, so that PRs and tags created by
+      # the release-plz-action can trigger actions workflows.
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # pull-requests permission is not needed for the `release` command, so restricting it to contents only
+          permission-contents: write
+      - name: Run `release-plz release`
+        uses: release-plz/action@acb9246af4d59a270d1d4058a8b9af8c3f3a2559 # v0.5.117
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This PR introduces two manual GitHub Actions workflows to manage the crate release process via Release-plz:

- **release-pr.yml** — Creates or updates a release preparation PR manually (`release-plz release-pr`).
- **release.yml** — Tags, publishes the crate to crates.io via trusted publishing (OIDC), and creates a GitHub release (`release-plz release`).

Both workflows:
- Use explicit `workflow_dispatch` triggers (manual start).
- Authenticate via a GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`).
- Restrict permissions for security and enable OIDC for trusted crates.io publishing.