### PR TITLE
feat(json): add `is_not_null` matcher; deprecate `any_value`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ use serde_json::json as j;
   `json::is_contained_in![...]` macro.
 - **Provide** clear, structured diagnostic failure messages showing which part of the JSON structure did not match and
   why.
-- **Helper matchers** for validating JSON kinds and structure: `json::is_null()`, `json::any_value()`,
+- **Helper matchers** for validating JSON kinds and structure: `json::is_null()`, `json::is_not_null()`,
   `json::is_string()`, `json::is_number()`, `json::is_boolean()`, `json::is_array()`, `json::is_object()`.
 
 ## Examples
@@ -289,7 +289,7 @@ assert_that!(
                 // array of arrays — demonstrate nesting twice
                 "matrix": json::elements_are![
                     json::is_contained_in![starts_with("al"), json::is_number()],
-                    json::is_contained_in![starts_with("be"), json::any_value(), json::is_string()]
+                    json::is_contained_in![starts_with("be"), json::is_not_null(), json::is_string()]
                 ],
 
                 // object with mixed matchers

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -4,7 +4,10 @@ mod matches_pattern_matcher;
 mod primitive_matcher;
 mod unordered_elements_are_matcher;
 
-pub use json_matcher::{any_value, is_array, is_boolean, is_null, is_number, is_object, is_string};
+#[allow(deprecated)]
+pub use json_matcher::{
+    any_value, is_array, is_boolean, is_not_null, is_null, is_number, is_object, is_string,
+};
 
 #[allow(deprecated)]
 #[doc(inline)]

--- a/src/matchers/json_matcher.rs
+++ b/src/matchers/json_matcher.rs
@@ -8,6 +8,12 @@ pub fn is_null() -> JsonPredicateMatcher {
 }
 
 /// Matches any JSON value except null.
+pub fn is_not_null() -> JsonPredicateMatcher {
+    JsonPredicateMatcher::new(|v| !v.is_null(), "not JSON null", "which is JSON null")
+}
+
+/// Matches any JSON value except null.
+#[deprecated(since = "0.2.2", note = "Use `is_not_null` instead")]
 pub fn any_value() -> JsonPredicateMatcher {
     JsonPredicateMatcher::new(
         |v| !v.is_null(),

--- a/tests/json_test.rs
+++ b/tests/json_test.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use googletest::prelude::*;
 use googletest_json_serde::json;
 use indoc::indoc;
@@ -20,6 +22,30 @@ fn any_value_fails_and_includes_full_message() -> Result<()> {
             r#"
             Value of: json!(null)
             Expected: any JSON value
+            Actual: Null,
+              which is a JSON null
+            "#
+        ))))
+    )
+}
+
+#[test]
+fn is_not_null_match() {
+    assert_that!(json!("2112"), json::is_not_null());
+}
+#[test]
+fn is_not_null_unmatch() {
+    assert_that!(json!(null), not(json::is_not_null()));
+}
+#[test]
+fn is_not_null_fails_and_includes_full_message() -> Result<()> {
+    let result = verify_that!(json!(null), json::is_not_null());
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            r#"
+            Value of: json!(null)
+            Expected: not JSON null
             Actual: Null,
               which is a JSON null
             "#

--- a/tests/matches_pattern_test.rs
+++ b/tests/matches_pattern_test.rs
@@ -106,7 +106,7 @@ fn match_object_with_any_value_field() {
         val,
         json::pat!({
             "field": eq("value"),
-            "unexpected": json::any_value()
+            "unexpected": json::is_not_null()
         })
     );
 }


### PR DESCRIPTION
- Introduced `json::is_not_null()` to clearly represent any non-null JSON value
- Deprecated `json::any_value()` in favor of `is_not_null()` for spec accuracy
- Updated README examples and tests to use `is_not_null()`