### PR TITLE
feat(json): add support for direct serde_json::Value equality in JSON…

### DIFF
--- a/src/matchers/elements_are_matcher.rs
+++ b/src/matchers/elements_are_matcher.rs
@@ -10,13 +10,9 @@
 ///
 /// Callers should prefer the public-facing [`json::elements_are!`](crate::json::elements_are!) macro.
 ///
-/// # Notes
+/// # Examples
 ///
-/// Both JSON-aware and native GoogleTest matchers (such as `starts_with`, `contains_substring`) can be used directly.
-/// Wrapping with `json::primitive!` is no longer needed.
-///
-/// # Example
-///
+/// Basic usage:
 /// ```
 /// # use googletest::prelude::*;
 /// # use serde_json::json as j;
@@ -24,7 +20,11 @@
 /// let value = j!(["alex", "bart", "cucumberbatch"]);
 /// assert_that!(
 ///     value,
-///     json::elements_are![starts_with("a"), eq("bart"), char_count(eq(13))]
+///     json::elements_are![
+///         j!("alex"),
+///         starts_with("b"),
+///         char_count(eq(13))
+///     ]
 /// );
 /// ```
 ///
@@ -37,15 +37,17 @@
 /// assert_that!(
 ///     value,
 ///     json::elements_are![
-///         json::elements_are![eq("x"), eq("y")],
+///         json::elements_are![j!("x"), eq("y")],
 ///         json::elements_are![eq("z")]
 ///     ]
 /// );
 /// ```
 ///
-/// # See also
+/// # Notes
 ///
-/// [`googletest::matcher::Matcher`], [`crate::json::elements_are!`]
+///  - Both JSON-aware and native GoogleTest matchers (such as `starts_with`, `contains_substring`) can be used directly.
+///  - Wrapping with `json::primitive!` is no longer needed.
+///  - Direct `serde_json::Value` inputs (e.g. `json!(...)`) are supported and compared by structural equality.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __json_elements_are {

--- a/src/matchers/matches_pattern_matcher.rs
+++ b/src/matchers/matches_pattern_matcher.rs
@@ -45,6 +45,12 @@
 /// );
 /// ```
 ///
+/// # Notes
+///
+///  - Both JSON-aware and native GoogleTest matchers (such as `starts_with`, `contains_substring`) can be used directly.
+///  - Wrapping with `json::primitive!` is no longer needed.
+///  - Direct `serde_json::Value` inputs (e.g. `json!(...)`) are supported and compared by structural equality.
+///
 /// # Alias
 ///
 /// This macro is reexported as [`json::pat!`](crate::json::pat).

--- a/src/matchers/unordered_elements_are_matcher.rs
+++ b/src/matchers/unordered_elements_are_matcher.rs
@@ -11,18 +11,18 @@
 /// and vice versa. Matching fails if the input is not an array, if the number of
 /// elements and matchers differ, or if no perfect one-to-one mapping can be found.
 ///
-/// # Examples
+/// # Example
 ///
 /// This passes:
 /// ```
 /// # use googletest::prelude::*;
-/// # use serde_json::json;
+/// # use serde_json::json as j;
 /// # use crate::googletest_json_serde::json;
-/// let value = json!(["a", "b", "c"]);
+/// let value = j!(["a", "b", "c"]);
 /// assert_that!(
 ///     value,
 ///     json::unordered_elements_are![
-///         eq("c"),
+///         j!("c"),
 ///         eq("a"),
 ///         starts_with("b"),
 ///     ]
@@ -32,9 +32,9 @@
 /// This fails because the element `"x"` does not match any expected element:
 /// ```should_panic
 /// # use googletest::prelude::*;
-/// # use serde_json::json;
+/// # use serde_json::json as j;
 /// # use crate::googletest_json_serde::json;
-/// let value = json!(["a", "x", "c"]);
+/// let value = j!(["a", "x", "c"]);
 /// assert_that!(
 ///     value,
 ///     json::unordered_elements_are![
@@ -60,9 +60,12 @@
 /// );
 /// ```
 ///
-/// # Alias
 ///
-/// This macro is re-exported as [`json::unordered_elements_are!`](crate::json::unordered_elements_are).
+/// # Notes
+///
+///  - Both JSON-aware and native GoogleTest matchers (such as `starts_with`, `contains_substring`) can be used directly.
+///  - Wrapping with `json::primitive!` is no longer needed.
+///  - Direct `serde_json::Value` inputs (e.g. `json!(...)`) are supported and compared by structural equality.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __json_unordered_elements_are {
@@ -160,7 +163,13 @@ macro_rules! __json_contains_each {
 ///
 /// Accepts both bracketed (`json::is_contained_in!([ ... ])`) and unbracketed (`json::is_contained_in!(...)`) forms.
 ///
-/// Example:
+/// # Notes
+///
+///  - Both JSON-aware and native GoogleTest matchers (such as `starts_with`, `contains_substring`) can be used directly.
+///  - Wrapping with `json::primitive!` is no longer needed.
+///  - Direct `serde_json::Value` inputs (e.g. `json!(...)`) are supported and compared by structural equality.
+///
+/// # Example
 /// ```
 /// # use googletest::prelude::*;
 /// # use serde_json::json as j;

--- a/tests/contains_each_test.rs
+++ b/tests/contains_each_test.rs
@@ -216,3 +216,87 @@ fn contains_each_produces_correct_failure_message() -> Result<()> {
         ))))
     )
 }
+
+#[test]
+fn contains_each_mixed_types_match_with_owned_values() -> Result<()> {
+    let arr = vec![j!("alpha"), j!(1), j!(true)];
+    verify_that!(j!(arr), json::contains_each![eq("alpha"), eq(1), eq(true)])
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_borrowed_values() -> Result<()> {
+    let arr = [&j!("alpha"), &j!(1), &j!(true)];
+    verify_that!(
+        j!([arr[0], arr[1], arr[2]]),
+        json::contains_each![eq("alpha"), eq(1), eq(true)]
+    )
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_inline_borrowed_literals() -> Result<()> {
+    let a = j!("alpha");
+    let b = j!(1);
+    let c = j!(true);
+    verify_that!(
+        j!([&a, &b, &c]),
+        json::contains_each![eq("alpha"), eq(1), eq(true)]
+    )
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_inline_owned_literals() -> Result<()> {
+    verify_that!(
+        j!([j!("alpha"), j!(1), j!(true)]),
+        json::contains_each![eq("alpha"), eq(1), eq(true)]
+    )
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_mixed_owned_and_borrowed() -> Result<()> {
+    let a = j!("alpha");
+    verify_that!(
+        j!([&a, j!(1), j!(true)]),
+        json::contains_each![eq("alpha"), eq(1), eq(true)]
+    )
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_owned_values_unmatch() -> Result<()> {
+    let value = j!(["a", 1, false]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, not(json::contains_each![a, one, t]))
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_borrowed_values_unmatch() -> Result<()> {
+    let value = j!(["a", 1, false]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, not(json::contains_each![&a, &one, &t]))
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_inline_borrowed_literals_unmatch() -> Result<()> {
+    verify_that!(
+        j!(["a", 1, false]),
+        not(json::contains_each![&j!("a"), &j!(1), &j!(true)])
+    )
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_inline_owned_literals_unmatch() -> Result<()> {
+    verify_that!(
+        j!(["a", 1, false]),
+        not(json::contains_each![j!("a"), j!(1), j!(true)])
+    )
+}
+
+#[test]
+fn contains_each_mixed_types_match_with_mixed_owned_and_borrowed_unmatch() -> Result<()> {
+    let value = j!(["a", 1, false]);
+    let a = j!("a");
+    verify_that!(value, not(json::contains_each![a, j!(1), &j!(true)]))
+}

--- a/tests/elements_are_test.rs
+++ b/tests/elements_are_test.rs
@@ -225,3 +225,77 @@ fn elements_are_dupes_unmatch() -> Result<()> {
     let value = j!(["x", "y"]);
     verify_that!(value, not(json::elements_are![eq("x"), eq("x")]))
 }
+
+#[test]
+fn elements_are_mixed_types_match_with_owned_values() -> Result<()> {
+    let value = j!(["a", 1, true]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, json::elements_are![a, one, t])
+}
+#[test]
+fn elements_are_mixed_types_match_with_borrowed_values() -> Result<()> {
+    let value = j!(["a", 1, true]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, json::elements_are![&a, &one, &t])
+}
+#[test]
+fn elements_are_mixed_types_match_with_inline_borrowed_literals() -> Result<()> {
+    verify_that!(
+        j!(["a", 1, true]),
+        json::elements_are![&j!("a"), &j!(1), &j!(true)]
+    )
+}
+#[test]
+fn elements_are_mixed_types_match_with_inline_owned_literals() -> Result<()> {
+    verify_that!(
+        j!(["a", 1, true]),
+        json::elements_are![j!("a"), j!(1), j!(true)]
+    )
+}
+#[test]
+fn elements_are_mixed_types_match_with_mixed_owned_and_borrowed() -> Result<()> {
+    let value = j!(["a", 1, true]);
+    let a = j!("a");
+    verify_that!(value, json::elements_are![a, j!(1), &j!(true)])
+}
+
+#[test]
+fn elements_are_mixed_types_match_with_owned_values_unmatch() -> Result<()> {
+    let value = j!(["a", 1, false]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, not(json::elements_are![a, one, t]))
+}
+#[test]
+fn elements_are_mixed_types_match_with_borrowed_values_unmatch() -> Result<()> {
+    let value = j!(["a", 1, false]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, not(json::elements_are![&a, &one, &t]))
+}
+#[test]
+fn elements_are_mixed_types_match_with_inline_borrowed_literals_unmatch() -> Result<()> {
+    verify_that!(
+        j!(["a", 1, false]),
+        not(json::elements_are![&j!("a"), &j!(1), &j!(true)])
+    )
+}
+#[test]
+fn elements_are_mixed_types_match_with_inline_owned_literals_unmatch() -> Result<()> {
+    verify_that!(
+        j!(["a", 1, false]),
+        not(json::elements_are![j!("a"), j!(1), j!(true)])
+    )
+}
+#[test]
+fn elements_are_mixed_types_match_with_mixed_owned_and_borrowed_unmatch() -> Result<()> {
+    let value = j!(["a", 1, false]);
+    let a = j!("a");
+    verify_that!(value, not(json::elements_are![a, j!(1), &j!(true)]))
+}

--- a/tests/is_contained_in_test.rs
+++ b/tests/is_contained_in_test.rs
@@ -155,3 +155,85 @@ fn is_contained_in_produces_correct_failure_message() -> Result<()> {
         ))))
     )
 }
+
+#[test]
+fn is_contained_in_mixed_types_match_with_owned_values() -> Result<()> {
+    let value = j!(["a", 1]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, json::is_contained_in![a, one, t])
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_borrowed_values() -> Result<()> {
+    let value = j!(["a", 1]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, json::is_contained_in![&a, &one, &t])
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_inline_borrowed_literals() -> Result<()> {
+    verify_that!(
+        j!(["a", 1]),
+        json::is_contained_in![&j!("a"), &j!(1), &j!(true)]
+    )
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_inline_owned_literals() -> Result<()> {
+    verify_that!(
+        j!(["a", 1]),
+        json::is_contained_in![j!("a"), j!(1), j!(true)]
+    )
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_mixed_owned_and_borrowed() -> Result<()> {
+    let value = j!(["a", 1]);
+    let a = j!("a");
+    verify_that!(value, json::is_contained_in![a, j!(1), &j!(true)])
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_owned_values_unmatch() -> Result<()> {
+    let value = j!(["x", 2]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, not(json::is_contained_in![a, one, t]))
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_borrowed_values_unmatch() -> Result<()> {
+    let value = j!(["x", 2]);
+    let a = j!("a");
+    let one = j!(1);
+    let t = j!(true);
+    verify_that!(value, not(json::is_contained_in![&a, &one, &t]))
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_inline_borrowed_literals_unmatch() -> Result<()> {
+    verify_that!(
+        j!(["x", 2]),
+        not(json::is_contained_in![&j!("a"), &j!(1), &j!(true)])
+    )
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_inline_owned_literals_unmatch() -> Result<()> {
+    verify_that!(
+        j!(["x", 2]),
+        not(json::is_contained_in![j!("a"), j!(1), j!(true)])
+    )
+}
+
+#[test]
+fn is_contained_in_mixed_types_match_with_mixed_owned_and_borrowed_unmatch() -> Result<()> {
+    let value = j!(["x", 2]);
+    let a = j!("a");
+    verify_that!(value, not(json::is_contained_in![a, j!(1), &j!(true)]))
+}

--- a/tests/unordered_elements_test.rs
+++ b/tests/unordered_elements_test.rs
@@ -197,3 +197,99 @@ fn unordered_elements_are_produces_correct_failure_message_nested() -> Result<()
         )))
     )
 }
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_owned_values() -> Result<()> {
+    let value = json!([true, 1, "a"]);
+    let a = json!("a");
+    let one = json!(1);
+    let t = json!(true);
+    verify_that!(value, json::unordered_elements_are![a, one, t])
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_borrowed_values() -> Result<()> {
+    let value = json!([1, true, "a"]);
+    let a = json!("a");
+    let one = json!(1);
+    let t = json!(true);
+    verify_that!(value, json::unordered_elements_are![&a, &one, &t])
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_inline_borrowed_literals() -> Result<()> {
+    verify_that!(
+        json!(["a", true, 1]),
+        json::unordered_elements_are![&json!("a"), &json!(1), &json!(true)]
+    )
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_inline_owned_literals() -> Result<()> {
+    verify_that!(
+        json!([true, "a", 1]),
+        json::unordered_elements_are![json!("a"), json!(1), json!(true)]
+    )
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_mixed_owned_and_borrowed() -> Result<()> {
+    let value = json!([1, true, "a"]);
+    let a = json!("a");
+    verify_that!(
+        value,
+        json::unordered_elements_are![a, json!(1), &json!(true)]
+    )
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_owned_values_unmatch() -> Result<()> {
+    let value = json!([true, 2, "b"]);
+    let a = json!("a");
+    let one = json!(1);
+    let t = json!(true);
+    verify_that!(value, not(json::unordered_elements_are![a, one, t]))
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_borrowed_values_unmatch() -> Result<()> {
+    let value = json!([false, "a", 2]);
+    let a = json!("a");
+    let one = json!(1);
+    let t = json!(true);
+    verify_that!(value, not(json::unordered_elements_are![&a, &one, &t]))
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_inline_borrowed_literals_unmatch() -> Result<()> {
+    verify_that!(
+        json!(["b", 2, false]),
+        not(json::unordered_elements_are![
+            &json!("a"),
+            &json!(1),
+            &json!(true)
+        ])
+    )
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_inline_owned_literals_unmatch() -> Result<()> {
+    verify_that!(
+        json!([false, "x", 9]),
+        not(json::unordered_elements_are![
+            json!("a"),
+            json!(1),
+            json!(true)
+        ])
+    )
+}
+
+#[test]
+fn unordered_elements_are_mixed_types_match_with_mixed_owned_and_borrowed_unmatch() -> Result<()> {
+    let value = json!([false, "z", 3]);
+    let a = json!("a");
+    verify_that!(
+        value,
+        not(json::unordered_elements_are![a, json!(1), &json!(true)])
+    )
+}


### PR DESCRIPTION
… matchers

Added support for using raw serde_json::Value instances directly inside JSON matcher macros. When provided, they now perform structural equality checks automatically.

Changes:
- Added JsonEqMatcher to handle owned value comparison.
- Implemented IntoJsonMatcher for both Value and &Value.
- Ensured consistent descriptions and explanations in test output.
- Updated matcher macros to accept direct serde_json::Value arguments.
- Added comprehensive tests for elements_are!, contains_each!, is_contained_in!, unordered_elements_are!, and pat! using owned, borrowed, inline, and mixed values.